### PR TITLE
HWKAPM-798 | HTTP recorder allow custom options

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -18,7 +18,9 @@
 import fetch from 'node-fetch';
 
 const CONSOLE_RECORDER = Symbol('CONSOLE_RECORDER');
-const HTTP_OPTIONS = Symbol('HTTP_OPTIONS');
+const AUTHORIZATION = Symbol('AUTHORIZATION');
+const ENDPOINT = Symbol('ENDPOINT');
+const TIMEOUT = Symbol('TIMEOUT');
 
 class NoOpRecorder {
     record() {
@@ -42,19 +44,15 @@ class ConsoleRecorder extends NoOpRecorder {
 }
 
 class HttpRecorder {
-    constructor(url, username, password, debug) {
+    constructor(url, username, password, debug = false, timeout = 0) {
         function auth(name, pass) {
             const namePass = `${name}:${pass}`;
             return `Basic ${new Buffer(namePass).toString('base64')}`;
         }
 
-        this[HTTP_OPTIONS] = {
-            endpoint: `${url}/hawkular/apm/traces/fragments`,
-            headers: {
-                Authorization: auth(username, password),
-                'Content-Type': 'application/json',
-            },
-        };
+        this[AUTHORIZATION] = auth(username, password);
+        this[ENDPOINT] = `${url}/hawkular/apm/traces/fragments`;
+        this[TIMEOUT] = timeout;
 
         if (debug) {
             this[CONSOLE_RECORDER] = new ConsoleRecorder();
@@ -72,10 +70,18 @@ class HttpRecorder {
             this[CONSOLE_RECORDER].record(span);
         }
 
-        fetch(this[HTTP_OPTIONS].endpoint, {
+        fetch(this[ENDPOINT], {
             method: 'POST',
             body: JSON.stringify([trace]),
-            headers: this[HTTP_OPTIONS].headers,
+            timeout: this[TIMEOUT],
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: this[AUTHORIZATION],
+            },
+        }).then((response) => {
+            if (response.status !== 204) {
+                console.log(`Server did not accept trace data: ${response}`);
+            }
         }).catch((err) => {
             console.log(`Error when reporting trace! Error: ${err}`);
         });


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKAPM-798

HTTP recorder accepts options object of underlying fetch-node.